### PR TITLE
feat: allow users to share their examples

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,7 +25,12 @@ import { ApplicationinsightsAngularpluginErrorService } from '@microsoft/applica
 import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
 import {
-  FaqComponent, SandboxControllerComponent, SideNavComponent, StreamComponent, StreamControllerComponent,
+  FaqComponent,
+  SandboxControllerComponent,
+  ShareButtonComponent,
+  SideNavComponent,
+  StreamComponent,
+  StreamControllerComponent,
   StreamOptionsComponent,
 } from './components';
 import { exampleProviders } from './examples';
@@ -65,6 +70,7 @@ import { routes } from './routes';
     StreamComponent,
     StreamControllerComponent,
     StreamOptionsComponent,
+    ShareButtonComponent,
   ],
   providers: [
     ...exampleProviders,
@@ -72,6 +78,6 @@ import { routes } from './routes';
     { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } },
     { provide: ErrorHandler, useClass: ApplicationinsightsAngularpluginErrorService },
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/src/app/components.ts
+++ b/src/app/components.ts
@@ -1,5 +1,6 @@
 export * from './components/faq/faq.component';
 export * from './components/sandbox-controller/sandbox-controller.component';
+export * from './components/share-button/share-button.component';
 export * from './components/side-nav/side-nav.component';
 export * from './components/stream-controller/stream-controller.component';
 export * from './components/stream-options/stream-options.component';

--- a/src/app/components/sandbox-controller/sandbox-controller.component.html
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.html
@@ -16,7 +16,6 @@
     <button
       *ngIf="canAddSource$ | async"
       mat-icon-button
-      matTooltip="Add input stream"
       aria-label="Add input stream"
       (click)="addInputStream()"
     >
@@ -41,7 +40,6 @@
         mat-raised-button
         color="primary"
         aria-label="Visualize output stream"
-        matTooltip="Visualize output stream from code block below"
         (click)="visualizeOutput()"
       >
         Visualize Output Stream

--- a/src/app/components/sandbox-controller/sandbox-controller.component.html
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.html
@@ -11,26 +11,22 @@
   </div>
 </div>
 
-<ng-container *ngIf="canAddSource$ | async; else hrule">
-  <div class="row">
-    <div class="col d-flex justify-content-center">
-      <button
-        mat-icon-button
-        matTooltip="Add input stream"
-        aria-label="Add input stream"
-        (click)="addInputStream()"
-      >
-        <mat-icon>add_box</mat-icon>
-      </button>
-    </div>
+<div class="row">
+  <div class="col d-flex justify-content-center">
+    <button
+      *ngIf="canAddSource$ | async"
+      mat-icon-button
+      matTooltip="Add input stream"
+      aria-label="Add input stream"
+      (click)="addInputStream()"
+    >
+      <mat-icon>add_box</mat-icon>
+    </button>
+    <app-share-button [url$]="shareUrl$"></app-share-button>
   </div>
+</div>
 
-  <hr class="mt-0" />
-</ng-container>
-
-<ng-template #hrule>
-  <hr />
-</ng-template>
+<hr class="mt-0" />
 
 <div class="row">
   <div class="col" *ngIf="output$ | async; else visualize; let output">

--- a/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
@@ -30,7 +30,7 @@ describe('SandboxControllerComponent', () => {
     inputStreamSpy = jasmine.createSpyObj<InputStreamLike>('InputStreamLike', ['updateNode']);
     executorServiceSpy = jasmine.createSpyObj<ExecutorService>('ExecutorService', ['getVisualizedOutput']);
     streamBuilderServiceSpy = jasmine.createSpyObj<StreamBuilderService>('StreamBuilderService', ['defaultInputStream']);
-    hashedExampleSpy = jasmine.createSpyObj<HashedExampleService>('ExampleHashService', ['getExample', 'getUrlTree']);
+    hashedExampleSpy = jasmine.createSpyObj<HashedExampleService>('ExampleHashService', ['getExample', 'getUrl']);
 
     exampleSpy = {
       ...jasmine.createSpyObj<Example>('Example', ['getInputStreams', 'getCode']),

--- a/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
@@ -88,10 +88,14 @@ describe('SandboxControllerComponent', () => {
 
   describe('properties', () => {
     describe('links$', () => {
-      it('should include serialized url for current example', () => {
-        const router = TestBed.inject(Router);
-        const serializeUrlSpy = spyOn(router, 'serializeUrl').and.returnValue('/hashed');
+      let serializeUrlSpy: jasmine.Spy<(u: UrlTree) => string>;
 
+      beforeEach(() => {
+        const router = TestBed.inject(Router);
+        serializeUrlSpy = spyOn(router, 'serializeUrl').and.returnValue('/hashed');
+      });
+
+      it('should include serialized url for current example', () => {
         expect(component.links$).toBeObservable(cold('0', [[
           { label: 'Current example', url: '/hashed' },
           { label: 'label', url: 'url' },
@@ -99,6 +103,16 @@ describe('SandboxControllerComponent', () => {
 
         expect(hashedExampleSpy.getUrlTree).toHaveBeenCalledWith(component.code$, component.sources$);
         expect(serializeUrlSpy).toHaveBeenCalledWith(urlTree);
+      });
+
+      it('should handle undefined links in pipe', () => {
+        exampleSpy.links = undefined;
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(component.links$).toBeObservable(cold('0', [[
+          { label: 'Current example', url: '/hashed' },
+        ]]));
       });
     });
 

--- a/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
@@ -15,6 +15,7 @@ import { SandboxControllerComponent } from './sandbox-controller.component';
 import { HashedExampleService } from "../../services/hashed-example.service";
 import { ActivatedRoute, ParamMap } from "@angular/router";
 import { RouteNames, RouteParamKeys } from "app-constants";
+import { ShareButtonComponent } from "../share-button/share-button.component";
 
 describe('SandboxControllerComponent', () => {
   let component: SandboxControllerComponent;
@@ -31,6 +32,7 @@ describe('SandboxControllerComponent', () => {
     executorServiceSpy = jasmine.createSpyObj<ExecutorService>('ExecutorService', ['getVisualizedOutput']);
     streamBuilderServiceSpy = jasmine.createSpyObj<StreamBuilderService>('StreamBuilderService', ['defaultInputStream']);
     hashedExampleSpy = jasmine.createSpyObj<HashedExampleService>('ExampleHashService', ['getExample', 'getUrl']);
+    hashedExampleSpy.getUrl.and.returnValue(cold('0', ['url']));
 
     exampleSpy = {
       ...jasmine.createSpyObj<Example>('Example', ['getInputStreams', 'getCode']),
@@ -52,6 +54,7 @@ describe('SandboxControllerComponent', () => {
       ],
       declarations: [
         SandboxControllerComponent,
+        MockComponent(ShareButtonComponent),
         MockComponent(StreamControllerComponent),
         MockComponent(CodemirrorComponent),
       ],
@@ -89,6 +92,13 @@ describe('SandboxControllerComponent', () => {
         expect(component.links$).toBeObservable(cold('0', [[
           { label: 'label', url: 'url' },
         ]]));
+      });
+    });
+
+    describe('shareUrl$', () => {
+      it('should be result of hashedExampleService.getUrl', () => {
+        expect(component.shareUrl$).toBeObservable(cold('0', ['url']));
+        expect(hashedExampleSpy.getUrl).toHaveBeenCalledWith(component.code$, component.sources$);
       });
     });
 

--- a/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
@@ -93,6 +93,17 @@ describe('SandboxControllerComponent', () => {
           { label: 'label', url: 'url' },
         ]]));
       });
+
+      describe('when example links are empty', () => {
+        beforeEach(() => {
+          exampleSpy.links = [];
+          component.ngOnInit();
+        });
+
+        it('should be undefined', () => {
+          expect(component.links$).toBeObservable(cold('0', [undefined]));
+        });
+      });
     });
 
     describe('shareUrl$', () => {

--- a/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
@@ -13,7 +13,7 @@ import { ExecutorService, RuntimeService, StreamBuilderService } from '../../ser
 import { StreamControllerComponent } from '../stream-controller/stream-controller.component';
 import { SandboxControllerComponent } from './sandbox-controller.component';
 import { HashedExampleService } from "../../services/hashed-example.service";
-import { ActivatedRoute, ParamMap, Router, UrlTree } from "@angular/router";
+import { ActivatedRoute, ParamMap } from "@angular/router";
 import { RouteNames, RouteParamKeys } from "app-constants";
 
 describe('SandboxControllerComponent', () => {
@@ -25,7 +25,6 @@ describe('SandboxControllerComponent', () => {
   let inputStreamSpy: jasmine.SpyObj<InputStreamLike>;
   let exampleSpy: jasmine.SpyObj<Example>;
   let hashedExampleSpy: jasmine.SpyObj<HashedExampleService>;
-  let urlTree: UrlTree;
 
   beforeEach(waitForAsync(() => {
     inputStreamSpy = jasmine.createSpyObj<InputStreamLike>('InputStreamLike', ['updateNode']);
@@ -66,19 +65,16 @@ describe('SandboxControllerComponent', () => {
           useValue: MockService(RuntimeService, {
             exampleSize$: of('large'),
             mediaSize$: of('large'),
-          } as Partial<RuntimeService>)
+          } as Partial<RuntimeService>),
         },
         { provide: HashedExampleService, useValue: hashedExampleSpy },
-      ]
+      ],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SandboxControllerComponent);
     component = fixture.componentInstance;
-
-    urlTree = { queryParams: {} } as UrlTree;
-    hashedExampleSpy.getUrlTree.and.returnValue(of(urlTree));
 
     fixture.detectChanges();
   });
@@ -89,30 +85,9 @@ describe('SandboxControllerComponent', () => {
 
   describe('properties', () => {
     describe('links$', () => {
-      let serializeUrlSpy: jasmine.Spy<(u: UrlTree) => string>;
-
-      beforeEach(() => {
-        const router = TestBed.inject(Router);
-        serializeUrlSpy = spyOn(router, 'serializeUrl').and.returnValue('/hashed');
-      });
-
-      it('should include serialized url for current example', () => {
+      it('should use example links', () => {
         expect(component.links$).toBeObservable(cold('0', [[
-          { label: 'Current example', url: '/hashed' },
           { label: 'label', url: 'url' },
-        ]]));
-
-        expect(hashedExampleSpy.getUrlTree).toHaveBeenCalledWith(component.code$, component.sources$);
-        expect(serializeUrlSpy).toHaveBeenCalledWith(urlTree);
-      });
-
-      it('should handle undefined links in pipe', () => {
-        exampleSpy.links = undefined;
-        component.ngOnInit();
-        fixture.detectChanges();
-
-        expect(component.links$).toBeObservable(cold('0', [[
-          { label: 'Current example', url: '/hashed' },
         ]]));
       });
     });
@@ -121,7 +96,7 @@ describe('SandboxControllerComponent', () => {
       expect(component.codeMirrorOptions).toEqual({
         lineNumbers: true,
         theme: 'material',
-        mode: 'text/typescript'
+        mode: 'text/typescript',
       });
 
       expect(component.formGroup).toBeInstanceOf(FormGroup);
@@ -195,7 +170,7 @@ describe('SandboxControllerComponent', () => {
       it('should use example', () => {
         const otherExample = {
           ...exampleSpy,
-          getInputStreams: () => ({large: [], small: []}),
+          getInputStreams: () => ({ large: [], small: [] }),
           getCode: () => 'otherCode',
           links: [],
         };

--- a/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.spec.ts
@@ -14,6 +14,7 @@ import { StreamControllerComponent } from '../stream-controller/stream-controlle
 import { SandboxControllerComponent } from './sandbox-controller.component';
 import { HashedExampleService } from "../../services/hashed-example.service";
 import { ActivatedRoute, ParamMap, Router, UrlTree } from "@angular/router";
+import { RouteNames, RouteParamKeys } from "app-constants";
 
 describe('SandboxControllerComponent', () => {
   let component: SandboxControllerComponent;
@@ -179,14 +180,14 @@ describe('SandboxControllerComponent', () => {
     });
   });
 
-  describe('when exampleName is "hashed"', () => {
+  describe(`when ${RouteParamKeys.ExampleName} is "${RouteNames.SharedExample}"`, () => {
     let route: ActivatedRoute;
     let paramMapSpy: jasmine.SpyObj<ParamMap>;
 
     beforeEach(() => {
       route = TestBed.inject(ActivatedRoute);
       paramMapSpy = jasmine.createSpyObj<ParamMap>(['get']);
-      paramMapSpy.get.and.returnValue('hashed');
+      paramMapSpy.get.and.returnValue(RouteNames.SharedExample);
       spyOnProperty(route, 'paramMap').and.returnValue(of(paramMapSpy));
     });
 

--- a/src/app/components/sandbox-controller/sandbox-controller.component.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.ts
@@ -2,7 +2,7 @@ import { BehaviorSubject, combineLatest, merge, mergeMap, of } from 'rxjs';
 import { distinctUntilChanged, first, map, tap, withLatestFrom } from 'rxjs/operators';
 import { Component, Inject, InjectionToken, OnInit, Optional } from '@angular/core';
 import { FormBuilder, FormControl } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Example, EXAMPLE, getFormValue, InputStreamLike, START_EXAMPLE, Stream } from '../../core';
 import { LoggerService } from '../../logger.service';
@@ -41,6 +41,8 @@ export class SandboxControllerComponent implements OnInit {
   output$ = this._outputSubject$.asObservable().pipe(distinctUntilChanged());
   links$ = this._linksSubject$.asObservable();
 
+  shareUrl$ = this._hashedExampleSvc.getUrl(this.code$, this.sources$);
+
   numberOfSources$ = this.sources$.pipe(
     map((sources) => sources.length ?? 0),
     distinctUntilChanged(),
@@ -63,7 +65,6 @@ export class SandboxControllerComponent implements OnInit {
     @Inject(START_EXAMPLE) protected _startExample: Example,
     @Inject(MAX_SOURCES) @Optional() maxSources: number | undefined,
     protected _route: ActivatedRoute,
-    protected _router: Router,
     protected _formBuilder: FormBuilder,
     protected _executorSvc: ExecutorService,
     protected _streamBuilder: StreamBuilderService,

--- a/src/app/components/sandbox-controller/sandbox-controller.component.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.ts
@@ -82,7 +82,7 @@ export class SandboxControllerComponent implements OnInit {
 
   protected renderExample(): void {
     const examples = this._examples.reduce(
-      (p, c) => ({...p, [c.name]: c}), {[this._startExample.name]: this._startExample}
+      (p, c) => ({ ...p, [c.name]: c }), { [this._startExample.name]: this._startExample },
     );
 
     const exampleToRender$ = this._route.paramMap.pipe(

--- a/src/app/components/sandbox-controller/sandbox-controller.component.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.ts
@@ -14,7 +14,7 @@ export const MAX_SOURCES = new InjectionToken<number>('Max number of sources.');
 @Component({
   selector: 'app-sandbox-controller',
   templateUrl: './sandbox-controller.component.html',
-  styleUrls: ['./sandbox-controller.component.scss']
+  styleUrls: ['./sandbox-controller.component.scss'],
 })
 @UntilDestroy()
 export class SandboxControllerComponent implements OnInit {
@@ -28,7 +28,7 @@ export class SandboxControllerComponent implements OnInit {
   codeMirrorOptions = {
     lineNumbers: true,
     theme: 'material',
-    mode: 'text/typescript'
+    mode: 'text/typescript',
   };
 
   formGroup = this._formBuilder.group<{ code: FormControl<string | null> }>({
@@ -39,14 +39,7 @@ export class SandboxControllerComponent implements OnInit {
 
   sources$ = this._sourcesSubject$.asObservable().pipe(distinctUntilChanged());
   output$ = this._outputSubject$.asObservable().pipe(distinctUntilChanged());
-  links$ = this._linksSubject$.asObservable().pipe(
-    mergeMap((links) => this._hashedExampleSvc.getUrlTree(this.code$, this.sources$).pipe(
-      map((urlTree) => [
-        { label: 'Current example', url: this._router.serializeUrl(urlTree) },
-        ...(links ?? []),
-      ])
-    )),
-  );
+  links$ = this._linksSubject$.asObservable();
 
   numberOfSources$ = this.sources$.pipe(
     map((sources) => sources.length ?? 0),

--- a/src/app/components/sandbox-controller/sandbox-controller.component.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.ts
@@ -39,7 +39,9 @@ export class SandboxControllerComponent implements OnInit {
 
   sources$ = this._sourcesSubject$.asObservable().pipe(distinctUntilChanged());
   output$ = this._outputSubject$.asObservable().pipe(distinctUntilChanged());
-  links$ = this._linksSubject$.asObservable();
+  links$ = this._linksSubject$.asObservable().pipe(
+    map((links) => !!links && links.length === 0 ? undefined : links),
+  );
 
   shareUrl$ = this._hashedExampleSvc.getUrl(this.code$, this.sources$);
 

--- a/src/app/components/sandbox-controller/sandbox-controller.component.ts
+++ b/src/app/components/sandbox-controller/sandbox-controller.component.ts
@@ -7,6 +7,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Example, EXAMPLE, getFormValue, InputStreamLike, START_EXAMPLE, Stream } from '../../core';
 import { LoggerService } from '../../logger.service';
 import { ExecutorService, HashedExampleService, RuntimeService, StreamBuilderService } from '../../services';
+import { RouteNames, RouteParamKeys } from "app-constants";
 
 export const MAX_SOURCES = new InjectionToken<number>('Max number of sources.');
 
@@ -86,8 +87,8 @@ export class SandboxControllerComponent implements OnInit {
     );
 
     const exampleToRender$ = this._route.paramMap.pipe(
-      map((params) => params.get('exampleName') ?? this._startExample.name),
-      mergeMap((name) => name !== 'hashed' ? of(examples[name]) : this._hashedExampleSvc.getExample(this._route)),
+      map((params) => params.get(RouteParamKeys.ExampleName) ?? this._startExample.name),
+      mergeMap((name) => name !== RouteNames.SharedExample ? of(examples[name]) : this._hashedExampleSvc.getExample(this._route)),
       map((example) => example ?? this._startExample),
     );
 

--- a/src/app/components/share-button/share-button.component.spec.ts
+++ b/src/app/components/share-button/share-button.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ShareButtonComponent } from './share-button.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Clipboard } from "@angular/cdk/clipboard";
+import { BehaviorSubject } from 'rxjs';
+import { DOCUMENT } from '@angular/common';
+import { MockModule } from "ng-mocks";
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from "@angular/material/button";
+
+describe('ShareButtonComponent', () => {
+  let component: ShareButtonComponent;
+  let fixture: ComponentFixture<ShareButtonComponent>;
+  let clipboardSvc: jasmine.SpyObj<Clipboard>;
+  let snackBarSvc: jasmine.SpyObj<MatSnackBar>;
+  let urlSubject$: BehaviorSubject<string>;
+
+  beforeEach(async () => {
+    clipboardSvc = jasmine.createSpyObj<Clipboard>('Clipboard', ['copy']);
+    snackBarSvc = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+    urlSubject$ = new BehaviorSubject<string>('/url-path?query=string');
+
+    await TestBed.configureTestingModule({
+      imports: [
+        MockModule(MatIconModule),
+        MockModule(MatButtonModule),
+      ],
+      providers: [
+        { provide: Clipboard, useValue: clipboardSvc },
+        { provide: MatSnackBar, useValue: snackBarSvc },
+      ],
+      declarations: [ ShareButtonComponent ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShareButtonComponent);
+    component = fixture.componentInstance;
+    component.url$ = urlSubject$.asObservable();
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('copyToClipboard', () => {
+    it('should copy the full URL to the clipboard', () => {
+      const document = TestBed.inject(DOCUMENT);
+      const currentOrigin = document.location.origin;
+
+      component.copyToClipboard();
+
+      expect(clipboardSvc.copy).toHaveBeenCalledWith(`${currentOrigin}/url-path?query=string`);
+      expect(snackBarSvc.open).toHaveBeenCalledWith(
+        'Copied URL for current example to clipboard',
+        'Close',
+        { duration: 3000 },
+      );
+    });
+  });
+});

--- a/src/app/components/share-button/share-button.component.spec.ts
+++ b/src/app/components/share-button/share-button.component.spec.ts
@@ -7,17 +7,20 @@ import { DOCUMENT } from '@angular/common';
 import { MockModule } from "ng-mocks";
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from "@angular/material/button";
+import { Router } from "@angular/router";
 
 describe('ShareButtonComponent', () => {
   let component: ShareButtonComponent;
   let fixture: ComponentFixture<ShareButtonComponent>;
   let clipboardSvc: jasmine.SpyObj<Clipboard>;
   let snackBarSvc: jasmine.SpyObj<MatSnackBar>;
+  let routerSvc: jasmine.SpyObj<Router>;
   let urlSubject$: BehaviorSubject<string>;
 
   beforeEach(async () => {
     clipboardSvc = jasmine.createSpyObj<Clipboard>('Clipboard', ['copy']);
     snackBarSvc = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+    routerSvc = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
     urlSubject$ = new BehaviorSubject<string>('/url-path?query=string');
 
     await TestBed.configureTestingModule({
@@ -28,6 +31,7 @@ describe('ShareButtonComponent', () => {
       providers: [
         { provide: Clipboard, useValue: clipboardSvc },
         { provide: MatSnackBar, useValue: snackBarSvc },
+        { provide: Router, useValue: routerSvc },
       ],
       declarations: [ ShareButtonComponent ],
     }).compileComponents();
@@ -46,18 +50,27 @@ describe('ShareButtonComponent', () => {
   });
 
   describe('copyToClipboard', () => {
+    beforeEach(() => {
+      component.copyToClipboard();
+    });
+
     it('should copy the full URL to the clipboard', () => {
       const document = TestBed.inject(DOCUMENT);
       const currentOrigin = document.location.origin;
 
-      component.copyToClipboard();
-
       expect(clipboardSvc.copy).toHaveBeenCalledWith(`${currentOrigin}/url-path?query=string`);
+    });
+
+    it('should display snackbar message', () => {
       expect(snackBarSvc.open).toHaveBeenCalledWith(
         'Current example URL copied to clipboard',
         'Ok',
         { duration: 3000 },
       );
+    });
+
+    it('should navigate to the initial URL', () => {
+      expect(routerSvc.navigateByUrl).toHaveBeenCalledWith('/url-path?query=string');
     });
   });
 });

--- a/src/app/components/share-button/share-button.component.spec.ts
+++ b/src/app/components/share-button/share-button.component.spec.ts
@@ -54,8 +54,8 @@ describe('ShareButtonComponent', () => {
 
       expect(clipboardSvc.copy).toHaveBeenCalledWith(`${currentOrigin}/url-path?query=string`);
       expect(snackBarSvc.open).toHaveBeenCalledWith(
-        'Copied URL for current example to clipboard',
-        'Close',
+        'Current example URL copied to clipboard',
+        'Ok',
         { duration: 3000 },
       );
     });

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -11,7 +11,6 @@ import { DOCUMENT } from "@angular/common";
   template: `
     <button
       mat-icon-button
-      matTooltip="URL to current example"
       aria-label="URL to current example"
       (click)="copyToClipboard()"
     >

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -39,8 +39,8 @@ export class ShareButtonComponent {
       tap((url) => this._logger.logDebug(this._name, 'Copying URL to clipboard', { url })),
       tap((url) => this._clipboard.copy(url)),
       tap(() => this._snackBar.open(
-        'Copied URL for current example to clipboard',
-        'Close',
+        'Current example URL copied to clipboard',
+        'Ok',
         { duration: 3000 },
       )),
     ).subscribe();

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -5,6 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { LoggerService } from '../../logger.service';
 import { first, map } from "rxjs/operators";
 import { DOCUMENT } from "@angular/common";
+import { Router } from "@angular/router";
 
 @Component({
   selector: 'app-share-button',
@@ -27,21 +28,23 @@ export class ShareButtonComponent {
   constructor(
     @Inject(DOCUMENT) private _document: Document,
     private _clipboard: Clipboard,
-    private _snackBar: MatSnackBar,
     private _logger: LoggerService,
+    private _router: Router,
+    private _snackBar: MatSnackBar,
   ) { }
 
   copyToClipboard() {
     this.url$.pipe(
       first(),
-      map((url) => `${this._document.location.origin}${url}`),
-      tap((url) => this._logger.logDebug(this._name, 'Copying URL to clipboard', { url })),
-      tap((url) => this._clipboard.copy(url)),
+      map((url) => ({ absoluteUrl: `${this._document.location.origin}${url}`, url })),
+      tap((urls) => this._logger.logDebug(this._name, 'Copying URL to clipboard', { urls })),
+      tap(({ absoluteUrl }) => this._clipboard.copy(absoluteUrl)),
       tap(() => this._snackBar.open(
         'Current example URL copied to clipboard',
         'Ok',
         { duration: 3000 },
       )),
+      tap(({ url }) => this._router.navigateByUrl(url)),
     ).subscribe();
   }
 }

--- a/src/app/components/share-button/share-button.component.ts
+++ b/src/app/components/share-button/share-button.component.ts
@@ -1,0 +1,48 @@
+import { Component, Inject, Input } from '@angular/core';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Observable, tap } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { LoggerService } from '../../logger.service';
+import { first, map } from "rxjs/operators";
+import { DOCUMENT } from "@angular/common";
+
+@Component({
+  selector: 'app-share-button',
+  template: `
+    <button
+      mat-icon-button
+      matTooltip="URL to current example"
+      aria-label="URL to current example"
+      (click)="copyToClipboard()"
+    >
+      <mat-icon>share</mat-icon>
+    </button>
+  `,
+})
+export class ShareButtonComponent {
+  private readonly _name = 'ShareButtonComponent';
+
+  @Input()
+  url$!: Observable<string>;
+
+  constructor(
+    @Inject(DOCUMENT) private _document: Document,
+    private _clipboard: Clipboard,
+    private _snackBar: MatSnackBar,
+    private _logger: LoggerService,
+  ) { }
+
+  copyToClipboard() {
+    this.url$.pipe(
+      first(),
+      map((url) => `${this._document.location.origin}${url}`),
+      tap((url) => this._logger.logDebug(this._name, 'Copying URL to clipboard', { url })),
+      tap((url) => this._clipboard.copy(url)),
+      tap(() => this._snackBar.open(
+        'Copied URL for current example to clipboard',
+        'Close',
+        { duration: 3000 },
+      )),
+    ).subscribe();
+  }
+}

--- a/src/app/core/constants.ts
+++ b/src/app/core/constants.ts
@@ -1,0 +1,2 @@
+export * from './constants/route-names';
+export * from './constants/route-param-keys';

--- a/src/app/core/constants/route-names.ts
+++ b/src/app/core/constants/route-names.ts
@@ -1,0 +1,3 @@
+export class RouteNames {
+  static readonly SharedExample = 'custom';
+}

--- a/src/app/core/constants/route-param-keys.ts
+++ b/src/app/core/constants/route-param-keys.ts
@@ -1,0 +1,3 @@
+export class RouteParamKeys {
+  static readonly ExampleName = 'exampleName';
+}

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -1,4 +1,5 @@
 export * from './services/executor.service';
+export * from './services/hashed-example.service';
 export * from './services/insights.service';
 export * from './services/local-storage.service';
 export * from './services/runtime.service';

--- a/src/app/services/hashed-example.service.spec.ts
+++ b/src/app/services/hashed-example.service.spec.ts
@@ -1,0 +1,162 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HashedExampleService } from './hashed-example.service';
+import { InputStreamLike } from "../core/types/stream";
+import { noop, Observable, of, tap } from "rxjs";
+import { ActivatedRoute, Router, UrlTree } from "@angular/router";
+import { StreamBuilderService } from "./stream.builder";
+import { InputStream } from "../core/stream";
+import { Example } from "../core/types/example";
+import { RouterTestingModule } from "@angular/router/testing";
+import { map } from "rxjs/operators";
+
+describe('HashedExampleService', () => {
+  let service: HashedExampleService;
+  let streamBuilderSpy: jasmine.SpyObj<StreamBuilderService>;
+  let router: Router;
+
+  beforeEach(() => {
+    streamBuilderSpy = jasmine.createSpyObj<StreamBuilderService>(['inputStream']);
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        { provide: StreamBuilderService, useValue: streamBuilderSpy },
+      ],
+    });
+
+    service = TestBed.inject(HashedExampleService);
+    router = TestBed.inject(Router);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getUrlTree', () => {
+    it('should return a url tree', (done) => {
+      const code$ = of('code');
+      const streams$ = of([
+        { marbles$: of({ marbles: 'marbles1', values: 'ignored' }) } as InputStreamLike,
+        { marbles$: of({ marbles: 'marbles2' }) } as InputStreamLike,
+      ] as InputStreamLike[]);
+      const routerUrlTreeSpy = spyOn(router, 'createUrlTree').and.returnValue({ queryParams: {} } as UrlTree);
+
+      service.getUrlTree(code$, streams$).subscribe((urlTree) => {
+        expect(urlTree).toEqual({ queryParams: { } } as UrlTree);
+        const expectedQueryParams ={
+          marbles: btoa(JSON.stringify([{ marbles: 'marbles1' }, { marbles: 'marbles2' }])),
+          code: btoa('code'),
+        };
+        expect(routerUrlTreeSpy).toHaveBeenCalledWith(['/hashed'], { queryParams: expectedQueryParams });
+        done();
+      });
+    });
+  });
+
+  describe('getExample', () => {
+    describe('when there is no query params', () => {
+      it('should return undefined', (done) => {
+        const route = jasmine.createSpyObj<ActivatedRoute>([], {
+          // eslint-disable-next-line rxjs/finnish
+          queryParams: undefined,
+        });
+
+        service.getExample(route).subscribe((example) => {
+          expect(example).toBeUndefined();
+          done();
+        });
+      });
+    });
+
+    describe('when query params does not have code', () => {
+      it('should return undefined', (done) => {
+        const marbles = 'marble-hash-goes-here';
+        const route = jasmine.createSpyObj<ActivatedRoute>([], {
+          // eslint-disable-next-line rxjs/finnish
+          queryParams: of({ marbles }),
+        });
+
+        service.getExample(route).subscribe((example) => {
+          expect(example).toBeUndefined();
+          done();
+        });
+      });
+    });
+
+    describe('when query params does not have marbles', () => {
+      it('should return undefined', (done) => {
+        const code = 'code';
+        const route = jasmine.createSpyObj<ActivatedRoute>([], {
+          // eslint-disable-next-line rxjs/finnish
+          queryParams: of({ code }),
+        });
+
+        service.getExample(route).subscribe((example) => {
+          expect(example).toBeUndefined();
+          done();
+        });
+      });
+    });
+  });
+
+  describe('Example from getExample', () => {
+    let example$: Observable<Example>;
+    let fakeInputStream: InputStream;
+    let originalCode: string;
+
+    beforeEach(() => {
+      const marbles = btoa(JSON.stringify([{ marbles: 'marbles1' }, { marbles: 'marbles2' }]));
+      originalCode = 'code';
+      const code = btoa(originalCode);
+      const route = jasmine.createSpyObj<ActivatedRoute>([], {
+        // eslint-disable-next-line rxjs/finnish
+        queryParams: of({ marbles, code }),
+      });
+      fakeInputStream = { offset: 1 } as InputStream;
+      streamBuilderSpy.inputStream.and.returnValue(fakeInputStream);
+
+      example$ = service.getExample(route).pipe(
+        tap((example) => !example ? fail('example is undefined') : noop()),
+        map((example) => example as Example),
+      );
+    });
+
+    describe('getInputStream', () => {
+      it('should return input streams from the query params', (done) => {
+        example$.subscribe((example) => {
+          expect(example).toBeDefined();
+          const inputStreams = example.getInputStreams();
+          expect(inputStreams).toEqual({
+            large: [fakeInputStream, fakeInputStream],
+            small: [fakeInputStream, fakeInputStream],
+          });
+          expect(streamBuilderSpy.inputStream).toHaveBeenCalledTimes(2);
+          expect(streamBuilderSpy.inputStream).toHaveBeenCalledWith({ marbles: 'marbles1' });
+          expect(streamBuilderSpy.inputStream).toHaveBeenCalledWith({ marbles: 'marbles2' });
+          done();
+        });
+      });
+    });
+
+    describe('getCode', () => {
+      it('should return code from the query params', (done) => {
+        example$.subscribe((example) => {
+          const code = example.getCode();
+          expect(code).toEqual(originalCode);
+          done();
+        });
+      });
+    });
+
+    describe('links', () => {
+      it('should return an empty array', (done) => {
+        example$.subscribe((example) => {
+          const links = example.links;
+          expect(links).toEqual([]);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/src/app/services/hashed-example.service.spec.ts
+++ b/src/app/services/hashed-example.service.spec.ts
@@ -152,10 +152,9 @@ describe('HashedExampleService', () => {
     });
 
     describe('links', () => {
-      it('should return an empty array', (done) => {
+      it('should return undefined', (done) => {
         example$.subscribe((example) => {
-          const links = example.links;
-          expect(links).toEqual([]);
+          expect(example.links).toEqual(undefined);
           done();
         });
       });

--- a/src/app/services/hashed-example.service.spec.ts
+++ b/src/app/services/hashed-example.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-
 import { HashedExampleService } from './hashed-example.service';
 import { InputStreamLike } from "../core/types/stream";
 import { noop, Observable, of, tap } from "rxjs";

--- a/src/app/services/hashed-example.service.spec.ts
+++ b/src/app/services/hashed-example.service.spec.ts
@@ -8,6 +8,7 @@ import { InputStream } from "../core/stream";
 import { Example } from "../core/types/example";
 import { RouterTestingModule } from "@angular/router/testing";
 import { map } from "rxjs/operators";
+import { RouteNames } from "app-constants";
 
 describe('HashedExampleService', () => {
   let service: HashedExampleService;
@@ -32,22 +33,24 @@ describe('HashedExampleService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('getUrlTree', () => {
-    it('should return a url tree', (done) => {
+  describe('getUrl', () => {
+    it('should return a serialized url tree', (done) => {
       const code$ = of('code');
       const streams$ = of([
         { marbles$: of({ marbles: 'marbles1', values: 'ignored' }) } as InputStreamLike,
         { marbles$: of({ marbles: 'marbles2' }) } as InputStreamLike,
       ] as InputStreamLike[]);
       const routerUrlTreeSpy = spyOn(router, 'createUrlTree').and.returnValue({ queryParams: {} } as UrlTree);
+      const routerSerializeUrlSpy = spyOn(router, 'serializeUrl').and.returnValue('url');
 
-      service.getUrlTree(code$, streams$).subscribe((urlTree) => {
-        expect(urlTree).toEqual({ queryParams: { } } as UrlTree);
+      service.getUrl(code$, streams$).subscribe((url) => {
+        expect(url).toEqual('url');
         const expectedQueryParams ={
           marbles: btoa(JSON.stringify([{ marbles: 'marbles1' }, { marbles: 'marbles2' }])),
           code: btoa('code'),
         };
-        expect(routerUrlTreeSpy).toHaveBeenCalledWith(['/hashed'], { queryParams: expectedQueryParams });
+        expect(routerUrlTreeSpy).toHaveBeenCalledWith([`/${RouteNames.SharedExample}`], { queryParams: expectedQueryParams });
+        expect(routerSerializeUrlSpy).toHaveBeenCalledWith({ queryParams: {} } as UrlTree);
         done();
       });
     });

--- a/src/app/services/hashed-example.service.ts
+++ b/src/app/services/hashed-example.service.ts
@@ -24,7 +24,7 @@ export class HashedExampleService {
     const inputStreams = marbles.map((m) => this._streamBuilder.inputStream(m));
     return {
       name: 'Hashed Example',
-      links: [],
+      links: undefined,
       section: 'other',
       getCode: () => code,
       getInputStreams: () => ({

--- a/src/app/services/hashed-example.service.ts
+++ b/src/app/services/hashed-example.service.ts
@@ -54,10 +54,6 @@ export class HashedExampleService {
   getExample(route: ActivatedRoute): Observable<Example | undefined> {
     return route.queryParams?.pipe(
       map((params) => {
-        if (!params) {
-          return undefined;
-        }
-
         const { marbles, code } = params;
         if (!marbles || !code) {
           return undefined;

--- a/src/app/services/hashed-example.service.ts
+++ b/src/app/services/hashed-example.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { LoggerService } from "../logger.service";
+import { InputMarbles, InputStreamLike } from "../core/types/stream";
+import { combineLatest, mergeMap, Observable, of } from "rxjs";
+import { ActivatedRoute, Router, UrlTree } from "@angular/router";
+import { Example } from "../core/types/example";
+import { map } from "rxjs/operators";
+import { StreamBuilderService } from "./stream.builder";
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HashedExampleService {
+  protected _name = 'HashedExampleService';
+
+  constructor(
+    protected _router: Router,
+    protected _streamBuilder: StreamBuilderService,
+    protected _logger: LoggerService,
+  ) { }
+
+  private createHashExample(code: string, marbles: Array<InputMarbles>): Example {
+    const inputStreams = marbles.map((m) => this._streamBuilder.inputStream(m));
+    return {
+      name: 'Hashed Example',
+      links: [],
+      section: 'other',
+      getCode: () => code,
+      getInputStreams: () => ({
+        small: inputStreams,
+        large: inputStreams,
+      }),
+    };
+  }
+
+  getUrlTree(code$: Observable<string>, streams$: Observable<InputStreamLike[]>): Observable<UrlTree> {
+    const hashedMarbles$ = streams$.pipe(
+      mergeMap((streams) => combineLatest(streams.map((stream) => stream.marbles$))),
+      map((allMarbles) => allMarbles.map(({ marbles }) => ({ marbles }))),
+      map((marbles) => btoa(JSON.stringify(marbles))),
+      map((hashedMarbles) => ({ marbles: hashedMarbles })),
+    );
+
+    const hashedCode$ = code$.pipe(
+      map((code) => ({ code: `${btoa(code)}` })),
+    );
+
+    return combineLatest([hashedMarbles$, hashedCode$]).pipe(
+      map(([{ marbles }, { code }]) => ({ marbles, code })),
+      map((queryParams) => this._router.createUrlTree(['/hashed'], { queryParams }))
+    );
+  }
+
+  getExample(route: ActivatedRoute): Observable<Example | undefined> {
+    return route.queryParams?.pipe(
+      map((params) => {
+        if (!params) {
+          return undefined;
+        }
+
+        const { marbles, code } = params;
+        if (!marbles || !code) {
+          return undefined;
+        }
+
+        const decodedMarbles = JSON.parse(atob(marbles));
+        const decodedCode = atob(code);
+
+        return this.createHashExample(decodedCode, decodedMarbles);
+      }),
+    ) ?? of(undefined);
+  }
+}

--- a/src/app/services/hashed-example.service.ts
+++ b/src/app/services/hashed-example.service.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router, UrlTree } from "@angular/router";
 import { Example } from "../core/types/example";
 import { map } from "rxjs/operators";
 import { StreamBuilderService } from "./stream.builder";
+import { RouteNames } from "app-constants";
 
 @Injectable({
   providedIn: 'root',
@@ -33,7 +34,7 @@ export class HashedExampleService {
     };
   }
 
-  getUrlTree(code$: Observable<string>, streams$: Observable<InputStreamLike[]>): Observable<UrlTree> {
+  getUrl(code$: Observable<string>, streams$: Observable<InputStreamLike[]>): Observable<string> {
     const hashedMarbles$ = streams$.pipe(
       mergeMap((streams) => combineLatest(streams.map((stream) => stream.marbles$))),
       map((allMarbles) => allMarbles.map(({ marbles }) => ({ marbles }))),
@@ -47,7 +48,11 @@ export class HashedExampleService {
 
     return combineLatest([hashedMarbles$, hashedCode$]).pipe(
       map(([{ marbles }, { code }]) => ({ marbles, code })),
-      map((queryParams) => this._router.createUrlTree(['/hashed'], { queryParams }))
+      map((queryParams) => this._router.createUrlTree(
+        [`/${RouteNames.SharedExample}`],
+        { queryParams },
+      )),
+      map((urlTree) => this._router.serializeUrl(urlTree)),
     );
   }
 

--- a/src/app/services/hashed-example.service.ts
+++ b/src/app/services/hashed-example.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { LoggerService } from "../logger.service";
 import { InputMarbles, InputStreamLike } from "../core/types/stream";
-import { combineLatest, mergeMap, Observable, of } from "rxjs";
-import { ActivatedRoute, Router, UrlTree } from "@angular/router";
+import { combineLatest, mergeMap, Observable, of, tap } from "rxjs";
+import { ActivatedRoute, Router } from "@angular/router";
 import { Example } from "../core/types/example";
 import { map } from "rxjs/operators";
 import { StreamBuilderService } from "./stream.builder";
@@ -53,10 +53,12 @@ export class HashedExampleService {
         { queryParams },
       )),
       map((urlTree) => this._router.serializeUrl(urlTree)),
+      tap((url) => this._logger.logDebug(this._name, 'getUrl', 'url', url)),
     );
   }
 
   getExample(route: ActivatedRoute): Observable<Example | undefined> {
+    this._logger.logDebug(this._name, 'getExample', 'route', route);
     return route.queryParams?.pipe(
       map((params) => {
         const { marbles, code } = params;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,11 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",
+    "paths": {
+      "app-constants": [
+        "src/app/core/constants"
+      ],
+    },
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
Updated to encode code and marbles as query parameters for link added to `References` as `Current example` which navigates to `/hashed?code={encryptedCode}&marbles={encryptedMarbles}`

When example name is `hashed`, sandbox-controller will use new `HashedExampleService` to create an `Example` to be used.

Closes #230

